### PR TITLE
feat: Add WSL-specific environment variable for X_AUTH_TOKEN and clear az creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ To run the application locally, follow these steps:
 6. **Run the application:**
 
     ```bash
+    #only on WSL
+    export X_AUTH_TOKEN=169ddeb1-502a-42cf-a222-9dbb8ec2cbf6
     uvicorn main:app --reload --port 6700
     ```
 

--- a/authenticator.py
+++ b/authenticator.py
@@ -1,4 +1,5 @@
 import json
+from math import log
 import os
 import re
 import subprocess
@@ -20,6 +21,15 @@ class AzureAuthenticator:
     async def get_device_code(self, user_id: str):
         # Set the environment variable
         env = self.set_env(user_id)
+        # run az logout to clear any existing sessions
+        logging.info("Logging out of Azure CLI...")
+        result = subprocess.run(['az', 'logout'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        # make sure the user is logged out
+        time.sleep(5)
+        if result.returncode != 0:
+            logging.error(f"Failed to logout: {result.stderr.decode('utf-8')}")
+        else:
+            logging.info("Logged out of Azure CLI.")
 
         # Execute the command
         child = pexpect.spawn('az login --use-device-code', env=env, timeout=120)


### PR DESCRIPTION
This commit adds an environment variable `X_AUTH_TOKEN` specifically for WSL (Windows Subsystem for Linux) in the README.md file. This variable is used to set the authentication token for the application when running on WSL. By including this variable in the instructions, it ensures that the application can authenticate properly in the WSL environment.

In addition, next time az devic code is called it clears the creds from the storage